### PR TITLE
Enhance `SearchParam`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [v1.0.2] - 2025-01-25
+
+### Added
+- Add `SearchParamChangeEvent` class extending `CustomEvent`
+- Add `multiple` support for `SearchParam`
+- `manageSearch` now uses `Proxy` to expose underlying properties and methods of values
+
+### Changed
+- Use calceleable `beforechange` event followed by a `change` event after
+
 ## [v1.0.1] - 2024-11-25
 
 ### Added

--- a/SearchParam.js
+++ b/SearchParam.js
@@ -1,24 +1,33 @@
+const valueSymbol = Symbol('param:value');
+const nameSymbol = Symbol('param:name');
+
 /**
  * Class representing a URL search parameter accessor.
  * Extends `EventTarget` to support listening for updates on the parameter.
  */
 export class SearchParam extends EventTarget {
 	#name;
+	#multiple = false;
 	#fallbackValue = '';
 
 	/**
 	 * Creates a search parameter accessor.
 	 * @param {string} name - The name of the URL search parameter to manage.
-	 * @param {string|number} fallbackValue - The default value if the search parameter is not set.
+	 * @param {string|number|Array} fallbackValue - The default value if the search parameter is not set. An array if `multiple` is true.
 	 */
-	constructor(name, fallbackValue) {
+	constructor(name, fallbackValue, { multiple = false } = {}) {
 		super();
 		this.#name = name;
-		this.#fallbackValue = fallbackValue;
+		this.#fallbackValue = multiple && ! Array.isArray(fallbackValue) ? Object.freeze([fallbackValue]) : Object.freeze(fallbackValue);
+		this.#multiple = multiple === true;
 	}
 
 	toString() {
-		return this.#value;
+		return this[SearchParam.valueSymbol];
+	}
+
+	[Symbol.iterator]() {
+		return this.#multiple ? this[valueSymbol] : [this[valueSymbol]];
 	}
 
 	get [Symbol.toStringTag]() {
@@ -26,11 +35,29 @@ export class SearchParam extends EventTarget {
 	}
 
 	[Symbol.toPrimitive](hint = 'default') {
-		return hint === 'number' ? parseFloat(this.#value) : this.#value;
+		return hint === 'number' ? parseFloat(this[valueSymbol]) : this[valueSymbol];
 	}
 
-	get #value() {
+	get [valueSymbol]() {
 		const params = new URLSearchParams(globalThis?.location.search);
-		return params.get(this.#name) ?? this.#fallbackValue?.toString() ?? '';
+
+		if (this.#multiple) {
+			const values = Object.freeze(params.getAll(this.#name));
+			return values.length === 0 ? this.#fallbackValue : values;
+		} else {
+			return params.get(this.#name) ?? this.#fallbackValue?.toString() ?? '';
+		}
+	}
+
+	get [nameSymbol]() {
+		return this.#name;
+	}
+
+	static get nameSymbol() {
+		return nameSymbol;
+	}
+
+	static get valueSymbol() {
+		return valueSymbol;
 	}
 }

--- a/event.js
+++ b/event.js
@@ -1,0 +1,1 @@
+export class SearchParamChangeEvent extends CustomEvent {}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@aegisjsproject/url",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@aegisjsproject/url",
-      "version": "1.0.1",
+      "version": "1.0.2",
       "funding": [
         {
           "type": "librepay",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aegisjsproject/url",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "Safe URL parsing/escaping via JS tagged templates",
   "keywords": [
     "aegis",

--- a/search.test.js
+++ b/search.test.js
@@ -1,0 +1,67 @@
+import { describe, test } from 'node:test';
+import { ok, strictEqual, deepStrictEqual, throws, doesNotReject, rejects } from 'node:assert';
+import { manageSearch } from './search.js';
+
+describe('Test `manageSearch()` functionality', () => {
+	// Need to polyfill parts of `location` and `history` APIs for node.
+	globalThis.location = new URL(import.meta.url);
+	globalThis.history = {
+		state: null,
+		replaceState(state, unused, url) {
+			this.state = state;
+			globalThis.location = new URL(url, location);
+		}
+	};
+
+	test('Test basic functionality', async () => {
+		const [param, setParam] = manageSearch('test');
+		const signal = AbortSignal.timeout(1);
+		ok(param.addEventListener instanceof Function, 'Should support event listeners.');
+
+		const promise = new Promise((resolve, reject) => {
+			signal.addEventListener('abort', ({ target }) => reject(target.reason), { once: true });
+			param.addEventListener('change', resolve, { signal, once: true });
+		});
+
+		doesNotReject(() => promise, 'Events should dispatch.');
+		setParam('works');
+		setParam(undefined);
+	});
+
+	test('Assure rejections work', async () => {
+		const [param] = manageSearch('test');
+		const signal = AbortSignal.timeout(1);
+
+		const promise = new Promise((resolve, reject) => {
+			signal.addEventListener('abort', ({ target }) => reject(target.reason), { once: true });
+			param.addEventListener('change', resolve, { signal });
+		});
+
+		rejects(() => promise, 'Events should dispatch.');
+	});
+
+	test('Test single string params', () => {
+		const [name, setName] = manageSearch('name', '');
+		strictEqual(name.length, 0, 'Should proxy to underlying string length.');
+		setName('Fred');
+		ok(name.substring instanceof Function, 'Methods of params should be proxied to values.');
+		strictEqual(name.substring(0), 'Fred', 'Updating param should update the value.');
+		strictEqual(name.length, 4, 'Updating param should update the value length.');
+		strictEqual(location.search, '?name=Fred', 'Should update location correctly.');
+		setName(undefined);
+		strictEqual(location.search.length, 0, 'Setting no/empty values should remove the search param.');
+	});
+
+	test('Test arrays and multiple values.', () => {
+		const [list, setList] = manageSearch('list', [], { multiple: true });
+		strictEqual(list.length, 0, 'Should start off with a length of 0');
+		setList(['one', 'two', 'three']);
+		deepStrictEqual(list.map(item => item.toUpperCase()), ['ONE', 'TWO', 'THREE'], 'Should expose underlying methods of array.');
+		setList([...list, 'four']);
+		throws(() => list.push('five'), { name: 'TypeError' }, 'Params should be immutable.');
+		strictEqual(list.length, 4, 'Should implement the iterator protocol and spread syntax, updating values.');
+		strictEqual(location.search, '?list=one&list=two&list=three&list=four', 'Should update the `list` search param with multiple values.');
+		setList([]);
+		strictEqual(location.search.length, 0, 'Setting no/empty values should remove the search param.');
+	});
+});

--- a/url.js
+++ b/url.js
@@ -1,3 +1,4 @@
 export { url, createURLParser } from './parser.js';
 export { SearchParam } from './SearchParam.js';
 export { getSearch, manageSearch } from './search.js';
+export { SearchParamChangeEvent } from './event.js';


### PR DESCRIPTION
### Added
- Add `SearchParamChangeEvent` class extending `CustomEvent`
- Add `multiple` support for `SearchParam`
- `manageSearch` now uses `Proxy` to expose underlying properties and methods of values

### Changed
- Use calceleable `beforechange` event followed by a `change` event after

# Description and issue

> Please add relevant sections (Added, removed, changed, fixed) to `CHANGELOG.md`

## List of significant changes made
-  
-  
